### PR TITLE
Remove references to contacting or emailing Steve

### DIFF
--- a/docs/catalyst_101.md
+++ b/docs/catalyst_101.md
@@ -122,7 +122,7 @@ Once the existing members have voted to offer you membership, it’s up to you t
 #### Accepting Membership
 
 - Sign the [Membership Agreement](https://drive.google.com/file/d/1tt4IXVwKi2Gj-L755AUZyu1QaVDRO8px/view?usp=sharing)
-- Purchase $1000 share, your initial capital contribution to the co-op, by sending us a check in the mail.
+- Purchase $1000 share, your initial capital contribution to the co-op, by sending Christina a check in the mail.
 
 (security)=
 

--- a/docs/catalyst_101.md
+++ b/docs/catalyst_101.md
@@ -95,9 +95,9 @@ When you’re first getting started, we’ll reach out to you about completing t
 #### Admin & PM Setup
 
 - Sign the Contractor Agreement
-- Send Steve W-9 / I-9 forms as needed
-- Send Steve your direct deposit information for payments
-- Set up relevant accounts and familiarize yourself with our [project management tools](https://docs.google.com/document/d/1EkKfdW0Q1AIGexCflZMpw-4HuH1fJ-cdpi3ziancmlE/edit#heading=h.yeh6v1ee9ind) (reach out to Zane or Steve for assistance)
+- Send Zane your W-9 / I-9 forms as needed
+- Send Zane your direct deposit information for payments
+- Set up relevant accounts and familiarize yourself with our [project management tools](https://docs.google.com/document/d/1EkKfdW0Q1AIGexCflZMpw-4HuH1fJ-cdpi3ziancmlE/edit#heading=h.yeh6v1ee9ind) (reach out to Zane for assistance)
 - Schedule 30 minute one-on-one meetings with existing contractors/members to get to know each other
 - Review our most recent [grant proposal](https://drive.google.com/drive/u/1/folders/1E0Stqvik_Vo6akfYmPwWtmywUfiHul0z) to see what we’ll be working on in the near term
 - Review the [Catalyst Policy Handbook](policies)
@@ -122,7 +122,7 @@ Once the existing members have voted to offer you membership, it’s up to you t
 #### Accepting Membership
 
 - Sign the [Membership Agreement](https://drive.google.com/file/d/1tt4IXVwKi2Gj-L755AUZyu1QaVDRO8px/view?usp=sharing)
-- Purchase $1000 share, your initial capital contribution to the co-op, by sending Steve a check in the mail.
+- Purchase $1000 share, your initial capital contribution to the co-op, by sending us a check in the mail.
 
 (security)=
 

--- a/docs/catalyst_101.md
+++ b/docs/catalyst_101.md
@@ -122,7 +122,8 @@ Once the existing members have voted to offer you membership, it’s up to you t
 #### Accepting Membership
 
 - Sign the [Membership Agreement](https://drive.google.com/file/d/1tt4IXVwKi2Gj-L755AUZyu1QaVDRO8px/view?usp=sharing)
-- Purchase $1000 share, your initial capital contribution to the co-op, by sending Christina a check in the mail.
+- Purchase $1000 share, your initial capital contribution to the co-op, by sending Christina a check in the mail or using ACH
+(for which there is a small fee).
 
 (security)=
 

--- a/docs/catalyst_howtos.md
+++ b/docs/catalyst_howtos.md
@@ -37,7 +37,7 @@ Most projects have a hourly budgets (monthly repeating or overall budgets) that 
 Categorizing hours worked on internal projects can be a little harder than client or grant work. For example, how might you charge the hour you spent researching grant opportunities? Here’s a description of the internal project options and how to decide between them:
 
 - **Advisory Committee:** This is reserved for the planning, agenda writing, and hosting of the quarterly advisory committee meeting.
-- **Admin:** You know… administrative work. This includes running payroll, financial reporting, invoicing clients, doing grant paperwork, and reorganizing the google drive. For the most part, Steve is the only one that will use this category.
+- **Admin:** You know… administrative work. This includes running payroll, financial reporting, invoicing clients, doing grant paperwork, and reorganizing the google drive.
 - **Business Development:** This is for general marketing/communications work, website additions, grant research, and work to make new relationships with folks that could be potential clients or collaborators.
 - **Governance:** This is for special member meetings and board calls.
 - **Hours Bike Rack**
@@ -51,7 +51,7 @@ Categorizing hours worked on internal projects can be a little harder than clien
 
 ### Choosing Tasks
 
-Once you’ve selected a project, you must also specify the type of task (e.g. **Code Review, Data Wrangling, or Phone / Meeting**). These help us understand what types of tasks we are spending time on. These should be pretty straightforward and self explanatory, but again don’t hesitate to ask about them or suggest changes. Not every project has every task listed as an option in the dropdown menu in Harvest. If you see a task here that ought to be an option for a project (or ought _not_ to be an option for a project). Let Steve know and he’ll fix it.
+Once you’ve selected a project, you must also specify the type of task (e.g. **Code Review, Data Wrangling, or Phone / Meeting**). These help us understand what types of tasks we are spending time on. These should be pretty straightforward and self explanatory, but again don’t hesitate to ask about them or suggest changes. Not every project has every task listed as an option in the dropdown menu in Harvest. If you see a task here that ought to be an option for a project (or ought _not_ to be an option for a project) feel free to fix it or let someone on the Admin team know. It's generally good practice not to add new categories mid-project unless everyone agrees.
 
 #### Tasks Descriptions and Intended Use
 
@@ -96,11 +96,11 @@ The **Notes** field is used to populate work descriptions that are reviewed inte
 
 - As much as possible, **separate time entries should be used for separate activities**. It’s helpful for us to know how much time we are spending doing research, for example, as opposed to software development, for a given client. If a client has questions or concerns about time entries, it is helpful to have more granular time entries rather than less granular time entries.
 - Time entries should **not include long breaks or meals** (e.g. if you are working on something and take a break for lunch, end the time entry and add a note). It’s OK to go to the bathroom! In fact, stay hydrated and drink some more water right now.
-- Time entries are **retroactively editable until they are processed and locked** at the end of the month. If you need to make changes after this point, contact Steve Winter.
+- Time entries are **retroactively editable until they are processed and locked** at the end of the month. If you need to make changes after this point, contact our Admin team.
 
 ### Tracking PTO
 
-You can find out how much PTO you have accrued by logging in to your gusto account and clicking on the “Time Off” menu option. If you want to use your PTO, email Steve and let him know the specifics. Make sure to contact him about applying PTO in or before the month you want to receive it.
+You can find out how much PTO you have accrued by logging in to your gusto account and clicking on the “Time Off” menu option. If you want to use your PTO, email Ben and let him know the specifics. Make sure to contact him about applying PTO in or before the month you want to receive it.
 
 ### Insights from Catalyst Time
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -140,7 +140,7 @@ Each member will be reimbursed **up to $3,000 in any rolling 3-year period** to 
 
 **Provided to:** Members only
 
-As a remote organization, Catalysters rarely see one another in person. To encourage folks to bridge the virtual divide, each member may request reimbursement for up to **$200 per year** for travel and food expenses related to visiting another member of the coop. These expenses must be _marginal and additional_ to existing plans where the primary purpose of the expenses is visiting another co-oper . Receipts must be submitted through the expense reimbursement form for approval and reimbursement.
+As a remote organization, Catalysters rarely see one another in person. To encourage folks to bridge the virtual divide, each member may request reimbursement for up to **$200 per year** for travel and food expenses related to visiting another member of the coop. These expenses must be _marginal and additional_ to existing plans where the primary purpose of the expenses is visiting another co-oper . Receipts must be submitted through the [Expense Reimbursement Form](https://drive.google.com/open?id=1rZxUUzib7Qb05Kz8aTxENd2QRv1d4oSEwQS-3OPsuX4) for approval and reimbursement.
 
 **Example:** A member seeks reimbursement for a flight to the other side of the country. They stay with their family friends for a week and then take a bus to a neighboring town to meet up with another co-oper and go out to lunch. Because the primary purpose of the flight is to see family and friends, the co-oper should foot the bill for the flight. The co-oper may request a reimbursement for travel to visit the other co-oper as well as the bill for their lunch together.
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -16,7 +16,7 @@ In line with our goal of allowing members time to pursue activities outside of w
 
 ### Annual Hours
 
-Each **member** must work at least **1000 hours per calendar year** in order to maintain their membership in the cooperative. This is equivalent to averaging 20 hours of work per week (or half of a normal 40 hr/week FTE). For new members who join the cooperative partway through the calendar year, this requirement will be prorated and applied only to the portion of the year during which they were working for the cooperative, including their 6 month candidacy period. Steven Winter shall only be required to work an average of 10 hours per week to retain his membership in the cooperative.
+Each **member** must work at least **1000 hours per calendar year** in order to maintain their membership in the cooperative. This is equivalent to averaging 20 hours of work per week (or half of a normal 40 hr/week FTE). For new members who join the cooperative partway through the calendar year, this requirement will be prorated and applied only to the portion of the year during which they were working for the cooperative, including their 6 month candidacy period.
 
 **Member-track contractors** must work **500 hours during a six month candidacy period** in order to be eligible for co-op membership.
 
@@ -140,8 +140,8 @@ Each member will be reimbursed **up to $3,000 in any rolling 3-year period** to 
 
 **Provided to:** Members only
 
-As a remote organization, Catalysters rarely see one another in person. To encourage folks to bridge the virtual divide, each member may request reimbursement for up to **$200 per year** for travel and food expenses related to visiting another member of the coop. These expenses must be _marginal and additional_ to existing plans where the primary purpose of the expenses is visiting another co-oper . Receipts must be submitted through the expense reimbursement form for approval by Steve and reimbursement.
+As a remote organization, Catalysters rarely see one another in person. To encourage folks to bridge the virtual divide, each member may request reimbursement for up to **$200 per year** for travel and food expenses related to visiting another member of the coop. These expenses must be _marginal and additional_ to existing plans where the primary purpose of the expenses is visiting another co-oper . Receipts must be submitted through the expense reimbursement form for approval and reimbursement.
 
 **Example:** A member seeks reimbursement for a flight to the other side of the country. They stay with their family friends for a week and then take a bus to a neighboring town to meet up with another co-oper and go out to lunch. Because the primary purpose of the flight is to see family and friends, the co-oper should foot the bill for the flight. The co-oper may request a reimbursement for travel to visit the other co-oper as well as the bill for their lunch together.
 
-If you are uncertain about whether an expense may be reimbursable, use your best judgment, and reach out to our Chief Financial Officer, Steve Winter, for clarification.
+If you are uncertain about whether an expense may be reimbursable, use your best judgment, and reach out to the Internal Management team for clarification.


### PR DESCRIPTION
### Describe the Policy Change
Not a policy change, just removing references to contact Steve.

### Reasoning and Concerns
Steve is no longer with the coop, and we don't want to encourage people to contact him about random stuff like PTO. This PR simply removes and replaces references to Steve throughout the docs. I wasn't 100% who to replace him with. Sometimes it was Zane (for tax and form stuff), sometimes it was Ben (for PTO stuff), and sometimes I just wrote the "admin team" or "us" which feels like a cop-out. If you know who to put instead, lmk! 
