### PR TITLE
Remove dead link: SBA guide to starting a worker coop

### DIFF
--- a/docs/catalyst_101.md
+++ b/docs/catalyst_101.md
@@ -51,8 +51,8 @@ Hold up. What _is_ a co-op? What makes it different from a non-profit or a regul
 - [The difference between co-ops and other types of corporations from the National Cooperative Business Association](https://ncbaclusa.coop/blog/differences-between-cooperatives-and-corporations/#:~:text=While%20other%20types%20of%20corporations,Some%20cooperatives%20are%20employee%2Downed.)
 - [The legal definition and status of co-ops from Co-opLaw.org](https://www.co-oplaw.org/knowledge-base/what-are-cooperatives/)
 - [The history of worker co-ops from the Federation of Worker Cooperatives](https://institute.coop/what-worker-cooperative)
-- [The steps involved in starting a worker coop from the US Small Business Administration](https://proxy.www.sba.gov/starting-business/choose-your-business-structure/cooperative)
-  [How coop finances work from the Internal Capital Accounts Group](https://icagroup.org/wp-content/uploads/2019/04/Internal-Capital-Accounts.pdf)
+- [The steps involved in starting a worker coop](https://www.toryburchfoundation.org/resources/start-my-business/choose-your-business-structure-cooperative/) (originally from the US Small Business Administration, copy hosted by the Tory Burch Foundation)
+- [How coop finances work from the Internal Capital Accounts Group](https://icagroup.org/wp-content/uploads/2019/04/Internal-Capital-Accounts.pdf)
 
 ### Catalyst’s Governing Documents
 


### PR DESCRIPTION
Page no longer exists; I couldn't find anything like it still on the SBA site.

### Describe the Policy Change

Just removing a link to a page that no longer exists

### Reasoning and Concerns

If the content is still needed, we could:
- find a better source for the same info
- link to the wayback machine: https://web.archive.org/web/20210713215421/https://proxy.www.sba.gov/starting-business/choose-your-business-structure/cooperative
- host our own copy of the content

[I just happened to notice this one, I've not checked for other dead links]