### PR TITLE
Skip notify action on failure so action passes on forks

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: custom
           fields: workflow,job,commit,repo,ref,author,took


### PR DESCRIPTION
This PR skips the `ci-notify` on failure because PRs from forks don't have access to the slack secret.