### PR TITLE
Apply 2023 COLA to fixed dollar amounts for benefits 

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -89,7 +89,7 @@ New members are granted 10 hours of paid time off to start with, to reflect the 
 
 **Provided to:** Members & Contractors
 
-Catalyst provides a healthcare reimbursement of **\$150 a month** to members and contractors working 1000 hours per year on a rolling 12 month basis (or in the case of new contractors/employees, the prorated amount of hours since they began working).
+Catalyst provides a healthcare reimbursement of **\$160 a month** to members and contractors working 1000 hours per year on a rolling 12 month basis (or in the case of new contractors/employees, the prorated amount of hours since they began working).
 
 (retirement-accounts)=
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -112,8 +112,8 @@ on retirement contributions.
 
 Catalyst has two reimbursement policies available to members:
 
-- [Home Office Reimbursements](home-office) \$3,300 / 3 years
-- [Catalyst IRL Reimbursements](irl-reimbursement) \$220 / year
+- [Home Office Reimbursements](home-office) \$3,200 / 3 years
+- [Catalyst IRL Reimbursements](irl-reimbursement) \$210 / year
 
 Reimbursement requests for one-off purchases approved by the board are also acceptable in certain circumstances.
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -112,8 +112,8 @@ on retirement contributions.
 
 Catalyst has two reimbursement policies available to members:
 
-- [Home Office Reimbursements](home-office) \$3,000 / 3 years
-- [Catalyst IRL Reimbursements](irl-reimbursement) \$200 / year
+- [Home Office Reimbursements](home-office) \$3,300 / 3 years
+- [Catalyst IRL Reimbursements](irl-reimbursement) \$220 / year
 
 Reimbursement requests for one-off purchases approved by the board are also acceptable in certain circumstances.
 


### PR DESCRIPTION
### Describe the Policy Change

Apply 2023 COLA to the fixed dollar value of our benefits. 

### Reasoning and Concerns

We decided to adjust the fixed dollar values of our benefits to track the CPI-U to keep up with inflation. [Link to the full discussion](https://docs.google.com/document/d/1m5m1gbFFYRpaWkKTFIvTSZ14HJT_jfGNDjneCNUP_ZI/edit#heading=h.gpm784ovmtiz).

For example, if we assume the November 2022 CPI-U was similar to the one reported for June,  meaning prices in November 2022 were 9.1% higher than prices in November 2021, then in mid-December we’d calculate our new dollar values for 2023 like this:

- Home office reimbursements cap: ($3000 x 1.091) = $3,273
- Monthly healthcare stipend: ($150 x 1.091) = $163.65/mo
- IRL Travel Reimbursement: ($200 x 1.091) = $218.20

Since round numbers are easier to remember and deal with generally, I propose that we just keep 2 significant figures, and round the calculated values. This would result in the following values from the example above:

- Home office: $3,300
- Healthcare: $160/mo
- IRL Travel: $220

